### PR TITLE
Path feature additions

### DIFF
--- a/dist/node/geom.js
+++ b/dist/node/geom.js
@@ -67,6 +67,67 @@ var doHalflinesCross = function doHalflinesCross(sa, sb) {
   return u >= -approx && v >= approx || u >= approx && v >= -approx;
 };
 
+var matrixTransform = function matrixTransform(points, matrix) {
+  return points.map(function (point) {
+    return {
+      x: point.x * matrix[0] + point.y * matrix[2] + matrix[4],
+      y: point.x * matrix[1] + point.y * matrix[3] + matrix[5]
+    };
+  });
+};
+
+var transformEllipse = function transformEllipse(rx, ry, ax, m) {
+  var torad = Math.PI / 180;
+  var epsilon = 0.0000000001;
+
+  var c = Math.cos(ax * torad),
+      s = Math.sin(ax * torad);
+  var ma = [rx * (m[0] * c + m[2] * s), rx * (m[1] * c + m[3] * s), ry * (-m[0] * s + m[2] * c), ry * (-m[1] * s + m[3] * c)];
+
+  var J = ma[0] * ma[0] + ma[2] * ma[2],
+      K = ma[1] * ma[1] + ma[3] * ma[3];
+
+  var D = ((ma[0] - ma[3]) * (ma[0] - ma[3]) + (ma[2] + ma[1]) * (ma[2] + ma[1])) * ((ma[0] + ma[3]) * (ma[0] + ma[3]) + (ma[2] - ma[1]) * (ma[2] - ma[1]));
+
+  var JK = (J + K) / 2;
+
+  if (D < epsilon * JK) {
+    return {
+      rx: Math.sqrt(JK),
+      ry: Math.sqrt(JK),
+      ax: 0,
+      isDegenerate: false
+    };
+  }
+
+  var L = ma[0] * ma[1] + ma[2] * ma[3];
+  D = Math.sqrt(D);
+
+  var l1 = JK + D / 2,
+      l2 = JK - D / 2;
+
+  var newAx = undefined,
+      newRx = undefined,
+      newRy = undefined;
+  newAx = Math.abs(L) < epsilon && Math.abs(l1 - K) < epsilon ? 90 : Math.atan(Math.abs(L) > Math.abs(l1 - K) ? (l1 - J) / L : L / (l1 - K)) * 180 / Math.PI;
+
+  if (newAx >= 0) {
+    newRx = Math.sqrt(l1);
+    newRy = Math.sqrt(l2);
+  } else {
+    newAx += 90;
+    newRx = Math.sqrt(l2);
+    newRy = Math.sqrt(l1);
+  }
+
+  return {
+    rx: newRx,
+    ry: newRy,
+    ax: newAx,
+    isDegenerate: newRx < epsilon * newRy || newRy < epsilon * newRx
+  };
+};
+
 exports["default"] = { distPointToPoint: distPointToPoint, distPointToParabol: distPointToParabol, circumCenter: circumCenter,
-  parabolsCrossX: parabolsCrossX, doHalflinesCross: doHalflinesCross };
+  parabolsCrossX: parabolsCrossX, doHalflinesCross: doHalflinesCross, matrixTransform: matrixTransform, transformEllipse: transformEllipse };
 module.exports = exports["default"];

--- a/dist/node/path.js
+++ b/dist/node/path.js
@@ -309,7 +309,10 @@ var Path = function Path(init) {
         params: [rx, ry, xrot, largeArcFlag, sweepFlag, x, y]
       });
     }),
-    translate: verbosify(['dx', 'dy'], function (dx, dy) {
+    translate: verbosify(['dx', 'dy'], function () {
+      var dx = arguments.length <= 0 || arguments[0] === undefined ? 0 : arguments[0];
+      var dy = arguments.length <= 1 || arguments[1] === undefined ? 0 : arguments[1];
+
       var prev = [0, 0];
       var newInstructions = _instructions.map(function (instruction) {
         var matrix = [1, 0, 0, 1, dx, dy];
@@ -319,7 +322,10 @@ var Path = function Path(init) {
       });
       return Path(newInstructions);
     }),
-    rotate: verbosify(['angle', 'rx', 'ry'], function (angle, rx, ry) {
+    rotate: verbosify(['angle', 'rx', 'ry'], function (angle) {
+      var rx = arguments.length <= 1 || arguments[1] === undefined ? 0 : arguments[1];
+      var ry = arguments.length <= 2 || arguments[2] === undefined ? 0 : arguments[2];
+
       if (angle !== 0) {
         var _ret = (function () {
           var prev = undefined;

--- a/dist/node/path.js
+++ b/dist/node/path.js
@@ -327,26 +327,27 @@ var Path = function Path(init) {
     }),
     scale: verbosify(['sx', 'sy'], function () {
       var sx = arguments.length <= 0 || arguments[0] === undefined ? 1 : arguments[0];
-      var sy = arguments.length <= 1 || arguments[1] === undefined ? 1 : arguments[1];
+      var sy = arguments.length <= 1 || arguments[1] === undefined ? sx : arguments[1];
+      return (function () {
+        if (sx !== 1 || sy !== 1) {
+          var _ret3 = (function () {
+            var prev = [0, 0];
+            var matrix = [sx, 0, 0, sy, 0, 0];
+            var newInstructions = _instructions.map(function (instruction) {
+              var p = transformParams(instruction, matrix, prev);
+              prev = point(instruction, prev);
+              return p;
+            });
+            return {
+              v: Path(newInstructions)
+            };
+          })();
 
-      if (sx !== 1 || sy !== 1) {
-        var _ret3 = (function () {
-          var prev = [0, 0];
-          var matrix = [sx, 0, 0, sy, 0, 0];
-          var newInstructions = _instructions.map(function (instruction) {
-            var p = transformParams(instruction, matrix, prev);
-            prev = point(instruction, prev);
-            return p;
-          });
-          return {
-            v: Path(newInstructions)
-          };
-        })();
-
-        if (typeof _ret3 === 'object') return _ret3.v;
-      } else {
-        return Path(_instructions);
-      }
+          if (typeof _ret3 === 'object') return _ret3.v;
+        } else {
+          return Path(_instructions);
+        }
+      })();
     }),
     shearX: verbosify(['angle'], function () {
       var angle = arguments.length <= 0 || arguments[0] === undefined ? 0 : arguments[0];

--- a/dist/node/path.js
+++ b/dist/node/path.js
@@ -313,21 +313,31 @@ var Path = function Path(init) {
       var dx = arguments.length <= 0 || arguments[0] === undefined ? 0 : arguments[0];
       var dy = arguments.length <= 1 || arguments[1] === undefined ? 0 : arguments[1];
 
-      var prev = [0, 0];
-      var newInstructions = _instructions.map(function (instruction) {
-        var matrix = [1, 0, 0, 1, dx, dy];
-        var p = transformParams(instruction, matrix, prev);
-        prev = point(instruction, prev);
-        return p;
-      });
-      return Path(newInstructions);
+      if (dx !== 0 || dx !== 0) {
+        var _ret = (function () {
+          var prev = [0, 0];
+          var matrix = [1, 0, 0, 1, dx, dy];
+          var newInstructions = _instructions.map(function (instruction) {
+            var p = transformParams(instruction, matrix, prev);
+            prev = point(instruction, prev);
+            return p;
+          });
+          return {
+            v: Path(newInstructions)
+          };
+        })();
+
+        if (typeof _ret === 'object') return _ret.v;
+      } else {
+        return Path(_instructions);
+      }
     }),
     rotate: verbosify(['angle', 'rx', 'ry'], function (angle) {
       var rx = arguments.length <= 1 || arguments[1] === undefined ? 0 : arguments[1];
       var ry = arguments.length <= 2 || arguments[2] === undefined ? 0 : arguments[2];
 
       if (angle !== 0) {
-        var _ret = (function () {
+        var _ret2 = (function () {
           var prev = undefined;
           var matrix = undefined;
           var newInstructions = _instructions;
@@ -369,7 +379,74 @@ var Path = function Path(init) {
           };
         })();
 
-        if (typeof _ret === 'object') return _ret.v;
+        if (typeof _ret2 === 'object') return _ret2.v;
+      } else {
+        return Path(_instructions);
+      }
+    }),
+    scale: verbosify(['sx', 'sy'], function () {
+      var sx = arguments.length <= 0 || arguments[0] === undefined ? 1 : arguments[0];
+      var sy = arguments.length <= 1 || arguments[1] === undefined ? 1 : arguments[1];
+
+      if (sx !== 1 || sy !== 1) {
+        var _ret3 = (function () {
+          var prev = [0, 0];
+          var matrix = [sx, 0, 0, sy, 0, 0];
+          var newInstructions = _instructions.map(function (instruction) {
+            var p = transformParams(instruction, matrix, prev);
+            prev = point(instruction, prev);
+            return p;
+          });
+          return {
+            v: Path(newInstructions)
+          };
+        })();
+
+        if (typeof _ret3 === 'object') return _ret3.v;
+      } else {
+        return Path(_instructions);
+      }
+    }),
+    shearX: verbosify(['angle'], function () {
+      var angle = arguments.length <= 0 || arguments[0] === undefined ? 0 : arguments[0];
+
+      if (angle !== 0) {
+        var _ret4 = (function () {
+          var prev = [0, 0];
+          var matrix = [1, 0, Math.tan(angle * Math.PI / 180), 1, 0, 0];
+          var newInstructions = _instructions.map(function (instruction) {
+            var p = transformParams(instruction, matrix, prev);
+            prev = point(instruction, prev);
+            return p;
+          });
+          return {
+            v: Path(newInstructions)
+          };
+        })();
+
+        if (typeof _ret4 === 'object') return _ret4.v;
+      } else {
+        return Path(_instructions);
+      }
+    }),
+    shearY: verbosify(['angle'], function () {
+      var angle = arguments.length <= 0 || arguments[0] === undefined ? 0 : arguments[0];
+
+      if (angle !== 0) {
+        var _ret5 = (function () {
+          var prev = [0, 0];
+          var matrix = [1, Math.tan(angle * Math.PI / 180), 0, 1, 0, 0];
+          var newInstructions = _instructions.map(function (instruction) {
+            var p = transformParams(instruction, matrix, prev);
+            prev = point(instruction, prev);
+            return p;
+          });
+          return {
+            v: Path(newInstructions)
+          };
+        })();
+
+        if (typeof _ret5 === 'object') return _ret5.v;
       } else {
         return Path(_instructions);
       }

--- a/src/geom.js
+++ b/src/geom.js
@@ -46,5 +46,70 @@ let doHalflinesCross = (sa, sb, approx = 1e-10) => { //sa, sb are Segment instan
   return (u>=-approx && v>=approx) || (u>=approx && v>=-approx)
 }
 
+let matrixTransform = (points, matrix) => {
+  return points.map(point => {
+    return {
+      x: point.x * matrix[0] + point.y * matrix[2] + matrix[4],
+      y: point.x * matrix[1] + point.y * matrix[3] + matrix[5]
+    }
+  })
+}
+
+let transformEllipse = (rx, ry, ax, m) => {
+  const torad = Math.PI / 180
+  const epsilon = 0.0000000001
+
+  let c = Math.cos(ax * torad), s = Math.sin(ax * torad)
+  let ma = [
+    rx * (m[0]*c + m[2]*s),
+    rx * (m[1]*c + m[3]*s),
+    ry * (-m[0]*s + m[2]*c),
+    ry * (-m[1]*s + m[3]*c)
+  ]
+
+  let J = ma[0]*ma[0] + ma[2]*ma[2],
+    K = ma[1]*ma[1] + ma[3]*ma[3]
+  
+  let D = ((ma[0]-ma[3])*(ma[0]-ma[3]) + (ma[2]+ma[1])*(ma[2]+ma[1])) *
+    ((ma[0]+ma[3])*(ma[0]+ma[3]) + (ma[2]-ma[1])*(ma[2]-ma[1]))
+
+  let JK = (J + K) / 2
+  
+  if (D < epsilon * JK) {
+    return {
+      rx: Math.sqrt(JK),
+      ry: Math.sqrt(JK),
+      ax: 0,
+      isDegenerate: false
+    }
+  }
+
+  let L = ma[0]*ma[1] + ma[2]*ma[3]
+  D = Math.sqrt(D)
+
+  let l1 = JK + D/2,
+    l2 = JK - D/2
+
+  let newAx, newRx, newRy
+  newAx = (Math.abs(L) < epsilon && Math.abs(l1 - K) < epsilon) ? 90
+    : Math.atan(Math.abs(L) > Math.abs(l1 - K) ? (l1 - J) / L : L / (l1 - K)) * 180 / Math.PI
+
+  if (newAx >= 0) {
+    newRx = Math.sqrt(l1)
+    newRy = Math.sqrt(l2)
+  } else {
+    newAx += 90;
+    newRx = Math.sqrt(l2)
+    newRy = Math.sqrt(l1)
+  }
+
+  return {
+    rx: newRx,
+    ry: newRy,
+    ax: newAx,
+    isDegenerate: (newRx < epsilon * newRy || newRy < epsilon * newRx)
+  }
+}
+
 export default { distPointToPoint, distPointToParabol, circumCenter,
-  parabolsCrossX, doHalflinesCross }
+  parabolsCrossX, doHalflinesCross, matrixTransform, transformEllipse }

--- a/src/path.js
+++ b/src/path.js
@@ -1,3 +1,5 @@
+import { matrixTransform, transformEllipse } from './geom'
+
 let Path = (init) => {
   let instructions = init || []
 
@@ -53,71 +55,6 @@ let Path = (init) => {
         return [params[0], params[1]]
       case 'A':
         return [params[5], params[6]]
-    }
-  }
-
-  let matrixTransform = (points, m) => {
-    return points.map(point => {
-      return {
-        x: point.x * m[0] + point.y * m[2] + m[4],
-        y: point.x * m[1] + point.y * m[3] + m[5]
-      }
-    })
-  }
-
-  let transformEllipse = (rx, ry, ax, m) => {
-    const torad = Math.PI / 180
-    const epsilon = 0.0000000001
-
-    let c = Math.cos(ax * torad), s = Math.sin(ax * torad)
-    let ma = [
-      rx * (m[0]*c + m[2]*s),
-      rx * (m[1]*c + m[3]*s),
-      ry * (-m[0]*s + m[2]*c),
-      ry * (-m[1]*s + m[3]*c)
-    ]
-
-    let J = ma[0]*ma[0] + ma[2]*ma[2],
-      K = ma[1]*ma[1] + ma[3]*ma[3]
-    
-    let D = ((ma[0]-ma[3])*(ma[0]-ma[3]) + (ma[2]+ma[1])*(ma[2]+ma[1])) *
-      ((ma[0]+ma[3])*(ma[0]+ma[3]) + (ma[2]-ma[1])*(ma[2]-ma[1]))
-
-    let JK = (J + K) / 2
-    
-    if (D < epsilon * JK) {
-      return {
-        rx: Math.sqrt(JK),
-        ry: Math.sqrt(JK),
-        ax: 0,
-        isDegenerate: false
-      }
-    }
-
-    let L = ma[0]*ma[1] + ma[2]*ma[3]
-    D = Math.sqrt(D)
-
-    let l1 = JK + D/2,
-      l2 = JK - D/2
-
-    let newAx, newRx, newRy
-    newAx = (Math.abs(L) < epsilon && Math.abs(l1 - K) < epsilon) ? 90
-      : Math.atan(Math.abs(L) > Math.abs(l1 - K) ? (l1 - J) / L : L / (l1 - K)) * 180 / Math.PI
-
-    if (newAx >= 0) {
-      newRx = Math.sqrt(l1)
-      newRy = Math.sqrt(l2)
-    } else {
-      newAx += 90;
-      newRx = Math.sqrt(l2)
-      newRy = Math.sqrt(l1)
-    }
-
-    return {
-      rx: newRx,
-      ry: newRy,
-      ax: newAx,
-      isDegenerate: (newRx < epsilon * newRy || newRy < epsilon * newRx)
     }
   }
 

--- a/src/path.js
+++ b/src/path.js
@@ -281,7 +281,7 @@ let Path = (init) => {
         return Path(instructions)
       }
     }),
-    scale: verbosify(['sx', 'sy'], (sx = 1, sy = 1) => {
+    scale: verbosify(['sx', 'sy'], (sx = 1, sy = sx) => {
       if (sx !== 1 || sy !== 1) {
         let prev = [0, 0]
         let matrix = [sx, 0, 0, sy, 0, 0]

--- a/src/path.js
+++ b/src/path.js
@@ -287,7 +287,7 @@ let Path = (init) => {
         params: [rx, ry, xrot, largeArcFlag, sweepFlag, x, y]
       })
     ),
-    translate: verbosify(['dx', 'dy'], (dx, dy) => {
+    translate: verbosify(['dx', 'dy'], (dx = 0, dy = 0) => {
       let prev = [0, 0]
       let newInstructions = instructions.map(instruction => {
         let matrix = [1, 0, 0, 1, dx, dy]
@@ -297,7 +297,7 @@ let Path = (init) => {
       })
       return Path(newInstructions)
     }),
-    rotate: verbosify(['angle', 'rx', 'ry'], (angle, rx, ry) => {
+    rotate: verbosify(['angle', 'rx', 'ry'], (angle, rx = 0, ry = 0) => {
       if (angle !== 0) {
         let prev
         let matrix

--- a/src/path.js
+++ b/src/path.js
@@ -288,14 +288,18 @@ let Path = (init) => {
       })
     ),
     translate: verbosify(['dx', 'dy'], (dx = 0, dy = 0) => {
-      let prev = [0, 0]
-      let newInstructions = instructions.map(instruction => {
+      if (dx !== 0 || dx !== 0) {
+        let prev = [0, 0]
         let matrix = [1, 0, 0, 1, dx, dy]
-        let p = transformParams(instruction, matrix, prev)
-        prev = point(instruction, prev)
-        return p
-      })
-      return Path(newInstructions)
+        let newInstructions = instructions.map(instruction => {
+          let p = transformParams(instruction, matrix, prev)
+          prev = point(instruction, prev)
+          return p
+        })
+        return Path(newInstructions)
+      } else {
+        return Path(instructions)
+      }
     }),
     rotate: verbosify(['angle', 'rx', 'ry'], (angle, rx = 0, ry = 0) => {
       if (angle !== 0) {
@@ -335,6 +339,48 @@ let Path = (init) => {
           })
         }
 
+        return Path(newInstructions)
+      } else {
+        return Path(instructions)
+      }
+    }),
+    scale: verbosify(['sx', 'sy'], (sx = 1, sy = 1) => {
+      if (sx !== 1 || sy !== 1) {
+        let prev = [0, 0]
+        let matrix = [sx, 0, 0, sy, 0, 0]
+        let newInstructions = instructions.map(instruction => {
+          let p = transformParams(instruction, matrix, prev)
+          prev = point(instruction, prev)
+          return p
+        })
+        return Path(newInstructions)
+      } else {
+        return Path(instructions)
+      }
+    }),
+    shearX: verbosify(['angle'], (angle = 0) => {
+      if (angle !== 0) {
+        let prev = [0, 0]
+        let matrix = [1, 0, Math.tan(angle * Math.PI / 180), 1, 0, 0]
+        let newInstructions = instructions.map(instruction => {
+          let p = transformParams(instruction, matrix, prev)
+          prev = point(instruction, prev)
+          return p
+        })
+        return Path(newInstructions)
+      } else {
+        return Path(instructions)
+      }
+    }),
+    shearY: verbosify(['angle'], (angle = 0) => {
+      if (angle !== 0) {
+        let prev = [0, 0]
+        let matrix = [1, Math.tan(angle * Math.PI / 180), 0, 1, 0, 0]
+        let newInstructions = instructions.map(instruction => {
+          let p = transformParams(instruction, matrix, prev)
+          prev = point(instruction, prev)
+          return p
+        })
         return Path(newInstructions)
       } else {
         return Path(instructions)

--- a/test/path.js
+++ b/test/path.js
@@ -111,6 +111,27 @@ describe('points method', () => {
     expect(path2Points).to.eql([[-36.6025, 63.3975], [19.3782, 100.3590], [60.3590, 111.3397], [13.3975, 150.0000]])
   })
 
+  it ('should report the expected points for the scale command', () => {
+    let path = Path().moveto(0, 0).lineto(0, 1).curveto(1, 1, 2, 5, 3, 1).arc(1, 1, 0, 0, 1, 1, 0).closepath()
+    let path2 = path.scale(3, 5)
+    expect(path2.points()).to.eql([[0, 0], [0, 5], [9, 5], [3, 0]])
+  })
+
+  it ('should report the expected points for the shearX command', () => {
+    let path = Path().moveto(0, 0).lineto(0, 1).curveto(1, 1, 2, 5, 3, 1).arc(1, 1, 0, 0, 1, 1, 0).closepath()
+    let path2 = path.shearX(30)
+    let path2Points = path2.points().map(point => [point[0].toFixed(4), point[1].toFixed(4)])
+    expect(path2Points).to.eql([[0, 0], [0.5774, 1], [3.5774, 1], [1, 0]])
+  })
+
+  it ('should report the expected points for the shearY command', () => {
+    let path = Path().moveto(0, 0).lineto(0, 1).curveto(1, 1, 2, 5, 3, 1).arc(1, 1, 0, 0, 1, 1, 0).closepath()
+    let path2 = path.shearY(30)
+    let path2Points = path2.points().map(point => [point[0].toFixed(4), point[1].toFixed(4)])
+
+    expect(path2Points).to.eql([[0, 0], [0, 1], [3, 2.7321], [1, 0.5774]])
+  })
+
   it('should allow multiple subpaths within the same path', () => {
     let path = Path().moveto(0,0).lineto(100,0).lineto(100,100).closepath().moveto(10,70).lineto(30,40).lineto(30,70).closepath()
     expect(path.points()).to.eql([[0, 0], [100, 0], [100, 100], [10, 70], [30, 40], [30, 70]])

--- a/test/path.js
+++ b/test/path.js
@@ -34,6 +34,11 @@ describe('path', () => {
     expect(path).to.have.property('smoothqcurveto')
     expect(path).to.have.property('arc')
     expect(path).to.have.property('points')
+    expect(path).to.have.property('translate')
+    expect(path).to.have.property('rotate')
+    expect(path).to.have.property('scale')
+    expect(path).to.have.property('shearX')
+    expect(path).to.have.property('shearY')
   })
 
   it('should ignore constructor arguments', () => {


### PR DESCRIPTION
Added `scale`, `shearX`, and `shearY` methods to `Path()`, and added tests for each of those methods.

A few other methods that I think would be useful, and would be happy to add:
`reverse` - to reverse the direction of the SVG path
`isClosed` - returns whether a given subpath is closed
`centroid` - returns centroid of all points
`midpoint` - returns the centroid of the bounding box

Let me know if you agree.

Oh, also: any reason why you don't export Path like so?
`export default Path`
This would allow you to pass an array of instructions on initialization of the `Path()`.

Alternatively (or additionally?) you could could pass an SVG string to `Path`, and it could be parsed into a `Path()`.