### PR TITLE
Prevent Crashes on Pie Charts

### DIFF
--- a/dist/node/pie.js
+++ b/dist/node/pie.js
@@ -28,6 +28,7 @@ exports['default'] = function (_ref) {
 
   var values = data.map(accessor);
   var s = (0, _ops.sum)(values);
+  s = s === 0 ? 1 : s;
   var scale = (0, _linear2['default'])([0, s], [0, 2 * Math.PI]);
   var curves = [];
   var t = 0;

--- a/src/pie.js
+++ b/src/pie.js
@@ -5,6 +5,7 @@ import { sum, enhance } from './ops'
 export default function({data, accessor, center, r, R, compute}) {
   let values = data.map(accessor)
   let s = sum(values)
+  s = (s === 0) ? 1 : s;
   let scale = Linear([0, s], [0, 2 * Math.PI])
   let curves = []
   let t = 0

--- a/test/pie.js
+++ b/test/pie.js
@@ -12,6 +12,17 @@ let data = [
   { hp: 60, attack: 45, defense: 50, sp_attack: 90, sp_defense: 80, speed: 70 }
 ]
 
+let data_empty = [
+  { hp: 0, attack: 49, defense: 49, sp_attack: 65, sp_defense: 65, speed: 45 },
+  { hp: 0, attack: 62, defense: 63, sp_attack: 80, sp_defense: 80, speed: 60 },
+  { hp: 0, attack: 82, defense: 83, sp_attack: 100, sp_defense: 100, speed: 80 },
+  { hp: 0, attack: 25, defense: 50, sp_attack: 25, sp_defense: 25, speed: 35 },
+  { hp: 0, attack: 64, defense: 58, sp_attack: 80, sp_defense: 65, speed: 80 },
+  { hp: 0, attack: 48, defense: 65, sp_attack: 50, sp_defense: 64, speed: 43 },
+  { hp: 0, attack: 83, defense: 100, sp_attack: 85, sp_defense: 105, speed: 78 },
+  { hp: 0, attack: 45, defense: 50, sp_attack: 90, sp_defense: 80, speed: 70 }
+]
+
 let pie = Pie({
   data: data,
   accessor: (x) => x.hp,
@@ -62,5 +73,17 @@ describe('pie chart', () => {
       R: 20
     })
     expect(pie.curves[0].sector.path.print()).to.equal('M 1 -19 A 20 20 0 1 1 0.998 -19 L 0.999 -9 A 10 10 0 1 0 1 -9 Z ')
+  })
+
+  it('should allow pies with empty data', () => {
+    let empty_pie = Pie({
+      data: data_empty,
+      accessor: (x) => x.hp,
+      center: [1, 1],
+      r: 10,
+      R: 20
+    })
+    // console.log('pie',empty_pie.curves[0].sector.path.print());
+    expect(empty_pie.curves[0].sector.path.print()).to.equal('M 1 -19 A 20 20 0 0 1 1 -19 L 1 -9 A 10 10 0 0 0 1 -9 Z ')
   })
 })

--- a/test/pie.js
+++ b/test/pie.js
@@ -83,7 +83,6 @@ describe('pie chart', () => {
       r: 10,
       R: 20
     })
-    // console.log('pie',empty_pie.curves[0].sector.path.print());
     expect(empty_pie.curves[0].sector.path.print()).to.equal('M 1 -19 A 20 20 0 0 1 1 -19 L 1 -9 A 10 10 0 0 0 1 -9 Z ')
   })
 })


### PR DESCRIPTION
A small fix I made while working on a personal project using [react-native-chart-kit](https://github.com/indiespirit/react-native-chart-kit). Currently, when I have a Pie chart with empty data values, the chart crashes. My fix is to default the sum to 1 in that case, so there's no 0 division, while the chart will remain empty. I tried to write a test case for this, but I'm not sure if it makes sense.

I hope this helps!